### PR TITLE
FUTURE BUG FIX: Avoid expect_that() in external process

### DIFF
--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -75,11 +75,12 @@ mainTests <- function(q){
   f <- future({
     b <- 4
     cons$consume()
-    expect_true(b == 2)
+    c <- b
     prod$fireEval(b <- 1)
-    3
+    c
   })
   v <- value(f)
+  expect_true(v == 2)
   cons$consume()
   expect_true(b == 1)
 }


### PR DESCRIPTION
Hi, author of the future package here.  In the next release, I'm most likely going to update `future()` such that it captures and relays all types of conditions, which is in contrast to the current version that captures and relays only conditions of class `message` and `warning` (plus `error` of course).


# Upcoming problem

When I ran reverse-package dependency tests, I found one problem with this new feateure and it kicks in with the package tests of your ipc package.  You can already now emulate this upcoming error by running the test as:
```diff
diff --git a/tests/testthat/test-main.R b/tests/testthat/test-main.R
index 5327fa7..02aa4a6 100644
--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -78,7 +78,7 @@ mainTests <- function(q){
     expect_true(b == 2)
     prod$fireEval(b <- 1)
     3
-  })
+  }, conditions = "condition")
   v <- value(f)
   cons$consume()
   expect_true(b == 1)
```

With future 1.13.0 and ipc 0.1.2, this will produce:
```r
> library(ipc)
> testthat::test_file("tests/testthat/test-main.R")
✔ |  OK F W S | Context
⠋ |   1       | MainError : Interrupt
Error : testerror
✖ |  15 1   1 | Main [4.1 s]
────────────────────────────────────────────────────────────────────────────────
test-main.R:90: error: Main Tests With TextFileSource
no 'restart' 'continue_test' found
1: mainTests(q) at tests/testthat/test-main.R:90
2: value(f) at tests/testthat/test-main.R:82
3: value.Future(f)
4: resignalConditions(future)
5: signalCondition(condition)
6: (function (e) 
   {
       handled <<- TRUE
       e$expectation_calls <- frame_calls(11, 6)
       register_expectation(e)
       invokeRestart("continue_test")
   })(structure(list(message = "b == 2 isn't true.", srcref = NULL), class = c("expectation_success", 
   "expectation", "condition")))
7: invokeRestart("continue_test")
8: stop(gettextf("no 'restart' '%s' found", as.character(r)), domain = NA)
```


# Troubleshooting

Rather technical and convoluted, but it turns out that this occurs because `expect_true(b == 2)`, which returns TRUE, also signals a condition `expectation_success`.  The future framework captures that condition with happens in the background worker and then resignals it in the main R process.  In the main R process, there is an active `testthat` `withCallingHandlers()` will capture this resignaled condition and try to call `invokeRestart("continue_test")` on it.  However, in the main R session there is no such restart point.  That one only exists locally in the `expect_true()` call.

# Patch
One could argue that it's incorrect to relay `expectation` conditions, that is, someone might say that the future package should ignore those.  However, one could also argue that the testthat framework should be updated to handle this case - which wouldn't be too hard.  A third alternative is to avoid writing code that calls testthat assertions in an external process.  In your case, the absolutely simplest fix would be to use `stopifnot()` instead;

```diff
diff --git a/tests/testthat/test-main.R b/tests/testthat/test-main.R
index 5327fa7..91cc729 100644
--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -75,7 +75,11 @@ mainTests <- function(q){
   f <- future({
     b <- 4
     cons$consume()
-    expect_true(b == 2)
+    ## We cannot use testthat::expect_true() in an external processes
+    ## because it will produce a 'expectation' condition that is
+    ## relayed in the main process while testthat does not expect
+    ## it to occur there;
+    stopifnot(b == 2)
     prod$fireEval(b <- 1)
     3
   })
```

The other solution is to manually add the type of restart point that testthat expects.
```diff
diff --git a/tests/testthat/test-main.R b/tests/testthat/test-main.R
index 5327fa7..ae91342 100644
--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -79,7 +79,12 @@ mainTests <- function(q){
     prod$fireEval(b <- 1)
     3
   })
-  v <- value(f)
+  ## WORKAROUND: Relay testthat expectation conditions with a
+  ## 'continue_test' restart point required by testthat just
+  ## it is done inside testthat::equal_true().
+  withRestarts({
+    v <- value(f)
+  }, continue_test = function() NULL)
   cons$consume()
   expect_true(b == 1)
 }
```

Yet another solution is simply to do the asserting via the value of the future, such that `expect_true()` is called in the main R process;

```diff
diff --git a/tests/testthat/test-main.R b/tests/testthat/test-main.R
index 5327fa7..7192d34 100644
--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -75,11 +75,12 @@ mainTests <- function(q){
   f <- future({
     b <- 4
     cons$consume()
-    expect_true(b == 2)
+    c <- b
     prod$fireEval(b <- 1)
-    3
+    c
   })
   v <- value(f)
+  expect_true(v == 2)
   cons$consume()
   expect_true(b == 1)
 }
```

In this PR, I went this the latter approach.